### PR TITLE
Fix bad gold test

### DIFF
--- a/test/genesis-ci.sh
+++ b/test/genesis-ci.sh
@@ -119,6 +119,7 @@ ENDGROUP
 
 ##############################################################################
 # COMPARE "gold" and "test"; use vcompare utility from aha repo
+printf ".\nCOMPARE gold and test models\n.\n"
 ls -l tmp-garnet.v[01]
 if ! test -e tmp-vcompare.sh; then
     docker cp ${container}:/aha/.buildkite/bin/vcompare.sh tmp-vcompare.sh
@@ -148,19 +149,16 @@ ndiffs=`vcompare $f1 $f2 | wc -l`
 if [ "$ndiffs" != "0" ]; then
     # ------------------------------------------------------------------------
     # TEST FAILED
-    printf ".\n.\n  Test FAILED\n  Test FAILED\n  Test FAILED\n.\n"
     printf "Test FAILED with $ndiffs diffs\n"
-    printf '(To update gold verilog, see $GARNET_REPO/bin/rtl-goldfetch.sh --help)'
     printf "\n"
     printf "Top 40 diffs:"
     vcompare $f1 $f2 | head -40
     printf ".\n.\n  Test FAILED\n  Test FAILED\n  Test FAILED\n.\n"
     exit 13
-else
-    # ------------------------------------------------------------------------
-    # TEST PASSED
-    printf ".\n.\n  Test PASSED\n  Test PASSED\n  Test PASSED\n.\n"
 fi
+# ------------------------------------------------------------------------
+# TEST PASSED
+printf ".\n.\n  Test PASSED\n  Test PASSED\n  Test PASSED\n.\n"
 
 # ...but what if master got corrupted and test-branch preserves that?
 # ...test will pass but answer is wrong??

--- a/test/genesis-ci.sh
+++ b/test/genesis-ci.sh
@@ -124,7 +124,10 @@ ls -l tmp-garnet.v[01]
 if ! test -e tmp-vcompare.sh; then
     docker cp ${container}:/aha/.buildkite/bin/vcompare.sh tmp-vcompare.sh
 fi
-function vcompare { ./tmp-vcompare.sh $*; }
+
+# Enhance vcompare with a prefilter to ignore comment lines :(
+function delcomms { egrep -v '^//' $1; }
+function vcompare { ./tmp-vcompare.sh <(delcomms $1) <(delcomms $2); }
 
 # docker kill $container  # Don't need this anymore because of TRAP
 
@@ -137,12 +140,6 @@ printf "\n"
 echo "Comparing `vcompare $f1 | wc -l` lines of $f1"
 echo "versus    `vcompare $f2 | wc -l` lines of $f2"
 printf "\n"
-
-echo "diff $f1 $f2"
-diff $f1 $f2
-
-
-
 
 ndiffs=`vcompare $f1 $f2 | wc -l`
 

--- a/test/genesis-ci.sh
+++ b/test/genesis-ci.sh
@@ -115,6 +115,7 @@ docker cp ${container}:/aha/garnet/genesis_verif tmp-gverif.d1/
 dexec 'cd /aha/garnet; make clean' >& /dev/null  # Clean up your mess, ignore errors :(
 ENDGROUP
 
+
 ##############################################################################
 # COMPARE "gold" and "test"; use vcompare utility from aha repo
 GROUP COMPARE gold and test models
@@ -156,7 +157,7 @@ done
 ENDGROUP
 # ------------------------------------------------------------------------
 # TEST PASSED
-printf ".\n.\n  Test PASSED\n  Test PASSED\n  Test PASSED\n.\n"
+printf ".\n  Test PASSED\n  Test PASSED\n  Test PASSED\n.\n"
 
 
 # ...but what if master got corrupted and test-branch preserves that?

--- a/test/genesis-ci.sh
+++ b/test/genesis-ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Uncomment to test failure path
-TEST_FAILURE_PATH=true
+# TEST_FAILURE_PATH=true
 
 USAGE="
   $0 <commit>

--- a/test/genesis-ci.sh
+++ b/test/genesis-ci.sh
@@ -95,7 +95,7 @@ if [ "$TEST_FAILURE_PATH" ]; then
     # FAULT INJECTION print("FOO Attempting fault injection")
     # FAULT INJECTION if os.path.isfile("/aha/garnet/genesis_verif/jtag.sv"):
     # FAULT INJECTION   print("FOO injecting error in /aha/garnet/genesis_verif/jtag.sv")
-    # FAULT INJECTION   r2 = os.system("set -x; bsed -i.bak 's/addr = 0/addr = 13/' /aha/garnet/genesis_verif/jtag.sv")
+    # FAULT INJECTION   r2 = os.system("set -x; sed -i.bak 's/addr = 0/addr = 13/' /aha/garnet/genesis_verif/jtag.sv")
     # FAULT INJECTION   print("FOO r2 = "); print (r2)
     # FAULT INJECTION   if r2 != 0: sys.exit(13)
     # FAULT INJECTION   print("FOO injection SUCCESSFULL...???")

--- a/test/genesis-ci.sh
+++ b/test/genesis-ci.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Uncomment to test failure path
+TEST_FAILURE_PATH=true
+
 USAGE="
   $0 <commit>
 
@@ -14,7 +17,7 @@ USAGE="
 if [ "$1" == "--help" ]; then echo "$USAGE"; exit; fi
 
 # What does this script do?
-# - verifies that tmp-garnet.v[01] does not exist already
+# - verifies that compare-dirs tmp-garnet.d[01] do not exist already
 # - launches a container based on garnet:latest
 # -- pip-installs latest genesis2 (maybe not necessary no more?)
 # -- builds gold verilog tmp-garnet.v0 using master branch
@@ -86,7 +89,30 @@ GROUP "TEST-BUILD ($commit) > tmp-garnet.v1"
 printf "\nINFO Build test-model verilog using Genesis2 branch '$commit'\n"
 REPO=/aha/lib/python3.8/site-packages/Genesis2-src
 dexec "set -x; cd $REPO; git pull; git checkout -fq $commit" || exit 13
+if [ "$TEST_FAILURE_PATH" ]; then
+    # Inject a fault in Genesis2.pl
+    # FAULT INJECTION 
+    # FAULT INJECTION print("FOO Attempting fault injection")
+    # FAULT INJECTION if os.path.isfile("/aha/garnet/genesis_verif/jtag.sv"):
+    # FAULT INJECTION   print("FOO injecting error in /aha/garnet/genesis_verif/jtag.sv")
+    # FAULT INJECTION   r2 = os.system("set -x; bsed -i.bak 's/addr = 0/addr = 13/' /aha/garnet/genesis_verif/jtag.sv")
+    # FAULT INJECTION   print("FOO r2 = "); print (r2)
+    # FAULT INJECTION   if r2 != 0: sys.exit(13)
+    # FAULT INJECTION   print("FOO injection SUCCESSFULL...???")
+    # FAULT INJECTION 
+    fault=$(egrep '^    # FAULT INJECTION' $0 | sed 's/.*INJECTION //' > /tmp/tmp$$)
+    dexec "cp /aha/bin/Genesis2.pl /aha/bin/Genesis2.pl0"
+    docker cp /tmp/tmp$$ $container:/tmp; # /bin/rm /tmp/tmp$$
+    dexec "cat /tmp/tmp$$ >> /aha/bin/Genesis2.pl"
+    dexec "diff /aha/bin/Genesis2.pl0 /aha/bin/Genesis2.pl"
+fi
 dexec "$build_garnet"
+if [ "$TEST_FAILURE_PATH" ]; then
+    set -x  # Show injected fault
+    dexec 'set -x; ls -l /aha/garnet/genesis_verif/'
+    dexec 'set -x; diff /aha/garnet/genesis_verif/jtag.{sv.bak,sv}'
+    set +x
+fi
 docker cp ${container}:/aha/garnet/garnet.v tmp-garnet.v1
 dexec 'cd /aha/garnet; make clean' >& /dev/null  # Clean up your mess, ignore errors :(
 ENDGROUP
@@ -112,6 +138,11 @@ echo "versus    `vcompare $f2 | wc -l` lines of $f2"
 printf "\n"
 
 echo "diff $f1 $f2"
+diff $f1 $f2
+
+
+
+
 ndiffs=`vcompare $f1 $f2 | wc -l`
 
 if [ "$ndiffs" != "0" ]; then

--- a/test/genesis-ci.sh
+++ b/test/genesis-ci.sh
@@ -76,7 +76,7 @@ ENDGROUP
 ##############################################################################
 GROUP 'GOLD-BUILD (master) > tmp-garnet.v0'
 printf "\nINFO Build gold-model verilog using Genesis2 branch 'master'"
-dexec "$build_garnet"
+dexec "$build_garnet" || exit 13
 docker cp ${container}:/aha/garnet/garnet.v tmp-garnet.v0
 dexec 'cd /aha/garnet; make clean' >& /dev/null  # Clean up your mess, ignore errors :(
 ENDGROUP
@@ -106,7 +106,7 @@ if [ "$TEST_FAILURE_PATH" ]; then
     dexec "cat /tmp/tmp$$ >> /aha/bin/Genesis2.pl"
     dexec "diff /aha/bin/Genesis2.pl0 /aha/bin/Genesis2.pl"
 fi
-dexec "$build_garnet"
+dexec "$build_garnet" || exit 13
 if [ "$TEST_FAILURE_PATH" ]; then
     set -x  # Show injected fault
     dexec 'set -x; ls -l /aha/garnet/genesis_verif/'

--- a/test/genesis-ci.sh
+++ b/test/genesis-ci.sh
@@ -117,6 +117,7 @@ ENDGROUP
 
 ##############################################################################
 # COMPARE "gold" and "test"; use vcompare utility from aha repo
+GROUP COMPARE gold and test models
 printf ".\nCOMPARE gold and test models\n.\n"
 echo .; ls -l tmp-gverif.d0/ | sed 's/^/  /'
 if ! test -e tmp-vcompare.sh; then
@@ -141,6 +142,7 @@ for f in $files; do
     echo "  $f..."
     ndiffs=`vcompare $f1 $f2 | wc -l`
     if [ "$ndiffs" != "0" ]; then
+        ENDGROUP
         # ------------------------------------------------------------------------
         # TEST FAILED
         printf ".\nTest of $f FAILED with $ndiffs diff lines\n"


### PR DESCRIPTION
Prev gold-model test compared `garnet.v` master vs. test branch. But garnet.v is NOT produced by Genesis, it is generated with magma instead. So this was a bad test and it tested the wrong thing oh well.

The test has now been upgraded to test master vs. test branch on the ten garnet-related files that ARE generated with Genesis2 i.e.
```
     1  cfg_and_dbg_unq1.sv
     2  flop_unq1.sv
     3  flop_unq2.sv
     4  flop_unq3.sv
     5  glc_axi_addrmap.sv
     6  glc_axi_ctrl.sv
     7  glc_jtag_ctrl.sv
     8  global_controller.sv
     9  jtag.sv
    10  tap_unq1.sv
```
The test passes ONLY IF the ten files are sufficiently verilog-similar as generated by both master and ci-target branches.
