### PR TITLE
trigger gold workflow on PR

### DIFF
--- a/.github/workflows/gold.yml
+++ b/.github/workflows/gold.yml
@@ -1,7 +1,13 @@
 name: Gold-Compare and Functional Tests
 
-# Runs on every push. Note (I think) PR triggers at least one push?
-on: [push]
+# Runs on every push or pull request.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      -main
 
 # StackOverflow 58033366
 env:


### PR DESCRIPTION
Trigger the gold workflow on pull requests and on pushes. The pull-request trigger will cause the workflow to run when a PR is created or updated.