### PR TITLE
get_mod_param_list: handle params that are refs

### DIFF
--- a/PerlLibs/Genesis2/UniqueModule.pm
+++ b/PerlLibs/Genesis2/UniqueModule.pm
@@ -60,6 +60,8 @@ use Cwd 'abs_path';
 use File::Copy;
 use File::Spec::Functions;
 use List::Util qw(min max);
+use Data::Dumper;
+use Digest::SHA qw(sha256_hex);
 
 use FileHandle;
 use Env; # Make environment variables available
@@ -2340,6 +2342,7 @@ sub get_mod_param_list{
     next if $param =~ /^__/;
     my $abbrev = $abbrevs->{$param};
     my $val = $self->internal_get_param($param);
+    $val = $self->internal_get_ref_param_hash($val) if ref $val;
 
     if (defined $val) {
       $val =~ s/\./_/g;
@@ -2807,4 +2810,30 @@ sub check_if_self{
     return 1 if (ref($arg) eq ref($Genesis2::UniqueModule::myself) && $arg==$Genesis2::UniqueModule::myself);
     return 0;
 }
+
+# Convert a reference to a stable value
+# by hashing the dumped contents
+sub internal_get_ref_param_hash {
+  my $self = shift;
+  my $name = $self->{BaseModuleName}."->internal_get_ref_param_hash";
+  caller eq __PACKAGE__
+    or $self->error("$name: Call to a base class private method is not allowed");
+
+  my $ref = shift;
+  if (!ref $ref) {
+    $self->error("$name: expects a reference parameter");
+  }
+
+  # Make Data::Dumper output deterministic
+  local $Data::Dumper::Indent   = 0;
+  local $Data::Dumper::Terse    = 1;
+  local $Data::Dumper::Sortkeys = 1;
+
+  my $dump = Dumper($ref);
+  my $hash = sha256_hex($dump);
+
+  my $hash32b = substr($hash, 0, 8);
+  return "R$hash32b";
+}
+
 1;


### PR DESCRIPTION
Handle parameters that are references (ARRAY or HASH). Dump the sorted array/hash and then hash and return a 32b value to generate a hopefully stable representation o fthe data.