### PR TITLE
sort hash keys for consistency across runs

### DIFF
--- a/PerlLibs/Genesis2/UniqueModule.pm
+++ b/PerlLibs/Genesis2/UniqueModule.pm
@@ -504,7 +504,7 @@ sub exists_param{
 sub list_params{
   my $self = shift;
   my $name =  $self->{BaseModuleName}."->list_params";
-  my @prms = keys (%{$self->{Parameters}});
+  my @prms = sort keys (%{$self->{Parameters}});
   return @prms;
 }
 
@@ -756,7 +756,7 @@ sub search_subinst{
     my $self = shift;
     my $name = $self->{BaseModuleName}."->search_subinst";
     my %options = @_;
-    my @keys = keys %options;
+    my @keys = sort keys %options;
     my @results = ();
     my $from = $self->get_top();
     my $depth = 10000;
@@ -1903,7 +1903,7 @@ sub get_unq_styles {
   my $name = __PACKAGE__."->get_unq_styles";
   caller eq __PACKAGE__ || caller eq 'Genesis2::Manager'
       or error("$name: access restricted to ".__PACKAGE__." or Genesis2::Manager");
-  return keys(%UNQ_STYLES);
+  return sort keys(%UNQ_STYLES);
 }
 
 ## default_unq_style
@@ -2045,7 +2045,7 @@ sub set_param{
       (GENESIS2_PRIORITY)[$self->{ParametersPriority}].
       "=".$self->{ParametersPriority}."<--\n" 
       if $self->{Debug} & 4;
-  foreach $prm_name (keys %prm_hash){
+  foreach $prm_name (sort keys %prm_hash){
     if (!defined $self->{Parameters}->{$prm_name}){
       $self->{Parameters}->{$prm_name}->{Val} = $self->deep_copy($prm_hash{$prm_name}, $prm_name);
       $self->set_param_priority($prm_name, $self->{ParametersPriority});
@@ -2730,7 +2730,7 @@ sub compare_generated_files{
 	}
 	
 	# Do the mapping of words as requested
-	foreach my $key (keys %options){
+	foreach my $key (sort keys %options){
 	    $lineA =~ s/(^|\W)$key(?=\W|$)/$1$options{$key}/g if defined $lineA;
 	}
 	if (defined $lineA && defined $lineB){


### PR DESCRIPTION
When iterating over hash keys, sort the keys for consistency across runs.