### PR TITLE
set doc string to '' when undef

### DIFF
--- a/PerlLibs/Genesis2/ConfigHandler.pm
+++ b/PerlLibs/Genesis2/ConfigHandler.pm
@@ -649,6 +649,7 @@ sub extract_stats {
 #if($unq_module->{Parameters}->{$param}->{Pri} >= GENESIS2_INHERITANCE_PRIORITY || $param_is_recursive == 1){
             else {
                 $ParameterItem->{Doc}   = $unq_module->{Parameters}->{$param}->{Doc};
+                $ParameterItem->{Doc}   = '' if !defined $ParameterItem->{Doc};
                 $ParameterItem->{Range} = $unq_module->{Parameters}->{$param}->{Range}
                   if defined $unq_module->{Parameters}->{$param}->{Range};
                 $ParameterItem->{Opt} = $unq_module->{Parameters}->{$param}->{Opt}


### PR DESCRIPTION
Duplicates the code from true branch to false branch of if statement that sets the doc string to '' when it is undef. This fixes an issue where XML::Simple::XMLout emits "Use of uninitialized value" warnings when undefs appear in the data being serialized.

This only shows up when using a newer XML::Simple version than the one supplied with Genesis. (Observed with 2.25; version supplied is 1.40.)