### PR TITLE
UniqueModule::get_top: return Top member

### DIFF
--- a/PerlLibs/Genesis2/UniqueModule.pm
+++ b/PerlLibs/Genesis2/UniqueModule.pm
@@ -342,11 +342,7 @@ sub get_parent {
 ## Usage: my $top_module = $self->get_top();
 sub get_top {
     my $self = shift;
-    my $top  = $self;
-    while (defined $top->get_parent()) {
-        $top = $top->get_parent();
-    }
-    return $top;
+    return $self->{Top};
 }
 
 ## sub get_instance_name


### PR DESCRIPTION
Return the Top member from UniqueModule instead of walking the hierarchy to the root every time.

For a large test program, this cut get_top execution time from ~45s to ~4.5s.