### PR TITLE
new func to get all instances

### DIFF
--- a/PerlLibs/Genesis2/Manager.pm
+++ b/PerlLibs/Genesis2/Manager.pm
@@ -1208,7 +1208,7 @@ sub create_product_lists {
     #print { $synth_product_fh } "+incdir+".$self->{SynthDir}."\n";
 
     # Get a list of all instances in REVERSED DFS order
-    my @rev_dfs_list = $self->{TopObj}->search_subinst(Reverse => 1);
+    my @rev_dfs_list = $self->{TopObj}->get_all_insts();
 
     # Process the list into synth and verif single appearance file list
     my %seen         = ();

--- a/PerlLibs/Genesis2/UniqueModule.pm
+++ b/PerlLibs/Genesis2/UniqueModule.pm
@@ -936,6 +936,36 @@ sub get_subinst_array {
     return @inst_array;
 }
 
+## get_all_insts
+## Get an array of all instances and subinstances, obtained via
+## a DFS traversal. Reduced fuctionality compared with search_subinst.
+sub get_all_insts {
+    my $self    = shift;
+    my @results = ();
+
+    $self->_get_all_insts(\@results, 1000);
+    return @results;
+}
+
+## _get_all_insts
+## Internal function used to constrtuct the lists of all instances via
+## a DFS traversal. The result array is passed as a reference to aovid
+## unnecessary copying.
+sub _get_all_insts {
+    my $self    = shift;
+    my $results = shift;
+    my $depth   = shift;
+
+    if ($depth > 0) {
+        foreach my $inst_name (@{$self->{SubInstanceList}}) {
+            my $subinst = $self->get_subinst($inst_name);
+            $subinst->_get_all_insts($results, $depth - 1);
+        }
+    }
+
+    push(@$results, $self);
+}
+
 ## get_instance_path
 ## API method that returns a complete path to the instance object given
 ## Usage: my $inst_path = $inst_obj->get_instance_path();


### PR DESCRIPTION
Add a new function to get an unfiltered list of all instances. The list in constructed by performed depth-first traversal.

Use this new function in create_product_lists.

Provides performance benefits when dealing with very large numbers of instances.